### PR TITLE
Allow git CRLF

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -5,6 +5,7 @@
 	root = ~/src
 [core]
 	excludesfile = ~/.gitignore_global
+	whitespace = cr-at-eol
 [alias]
 	alias = !git config --get-regexp '^alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
 	s  = status


### PR DESCRIPTION
git でのファイル更新時に `^M` の diff が表示されてしまう問題に対応
CRLF の改行コードを `git config` で許容するようにした
ref. http://amano41.hatenablog.jp/entry/git-diff-treats-cr-at-eol-as-error