### PR TITLE
Add GitHub issues export script

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -1,42 +1,34 @@
 # macOS
-
 .DS_Store
 
 # sublime text
-
 sftp-config.json
 
 # vscode
-
-.vscode/
+/.vscode/
 
 # intellij idea
-
 .idea/
 \*.iml
 
 # node.js
-
-node_modules/
+/node_modules/
 
 # ansible
-
 \*.retry
 
 # direnv
-
 .envrc
 
 # Ruby
-
 .byebug_history
 
 # Python
-
 **pycache**/
 
 # Personal project settings
+/.memo/
+/.uuutee/
 
-.uuutee/
-
+# Claude
 **/.claude/settings.local.json

--- a/.zshrc
+++ b/.zshrc
@@ -102,6 +102,9 @@ alias gupdate="$DOTFILES_DIR/scripts/shell/git_update.sh"
 # git push && PR 作成URLの表示
 alias gp='git push -u origin HEAD && gh-pr-url'
 
+# GitHub issues export
+alias ghei='$DOTFILES_DIR/scripts/shell/gh-export-issues.sh'
+
 # ghq & hub
 alias cdg='cd $(ghq root)/$(ghq list | peco)'
 

--- a/scripts/shell/gh-export-issues.sh
+++ b/scripts/shell/gh-export-issues.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# GitHub Issues to Markdown Exporter
+# Usage: gh-export-issues [options] [owner/repo]
+# Options:
+#   -o, --output DIR    Output directory
+#   -h, --help          Show this help message
+
+set -euo pipefail
+
+# Default values
+OUTPUT_DIR=""
+REPO=""
+HELP=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            HELP=true
+            shift
+            ;;
+        *)
+            REPO="$1"
+            shift
+            ;;
+    esac
+done
+
+# Show help
+if [[ "$HELP" == true ]]; then
+    echo "GitHub Issues to Markdown Exporter"
+    echo "Usage: gh-export-issues [options] [owner/repo]"
+    echo ""
+    echo "Options:"
+    echo "  -o, --output DIR    Output directory"
+    echo "  -h, --help          Show this help message"
+    echo ""
+    echo "Default output directories:"
+    echo "  - Current repository: ./issues/"
+    echo "  - Specified repository: ./[repo-name]/issues/"
+    echo ""
+    echo "Examples:"
+    echo "  gh-export-issues                     # Export to ./issues/"
+    echo "  gh-export-issues owner/repo           # Export to ./repo/issues/"
+    echo "  gh-export-issues -o ~/Documents/issues owner/repo"
+    exit 0
+fi
+
+# Determine if we're using current repo or specified repo
+IS_CURRENT_REPO=false
+if [[ -z "$REPO" ]]; then
+    # Try to get repo from current directory
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+    if [[ -z "$REPO" ]]; then
+        echo "Error: No repository specified and not in a git repository."
+        echo "Please specify a repository (e.g., owner/repo) or run from within a repository."
+        exit 1
+    fi
+    IS_CURRENT_REPO=true
+fi
+
+# Extract repo name for directory
+REPO_NAME=$(echo "$REPO" | sed 's/.*\///')
+
+# Set output directory if not specified
+if [[ -z "$OUTPUT_DIR" ]]; then
+    if [[ "$IS_CURRENT_REPO" == true ]]; then
+        OUTPUT_DIR="./issues"
+    else
+        OUTPUT_DIR="./${REPO_NAME}/issues"
+    fi
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+echo "Exporting issues from repository: $REPO"
+echo "Output directory: $OUTPUT_DIR"
+
+# Export all issues (both open and closed)
+echo "Fetching issues..."
+gh issue list --repo "$REPO" --state all --limit 10000 --json number,title,body,state,createdAt,updatedAt,author,labels,assignees,comments | jq -r '.[] | @base64' | while read -r issue_data; do
+    # Decode the issue data
+    _jq() {
+        echo "${issue_data}" | base64 -d | jq -r "${1}"
+    }
+    
+    # Extract issue details
+    number=$(_jq '.number')
+    title=$(_jq '.title')
+    body=$(_jq '.body // ""')
+    state=$(_jq '.state')
+    created_at=$(_jq '.createdAt')
+    updated_at=$(_jq '.updatedAt')
+    author=$(_jq '.author.login // "unknown"')
+    
+    # Format filename (sanitize title for filesystem)
+    safe_title=$(echo "$title" | sed 's/[^a-zA-Z0-9._-]/_/g' | cut -c1-50)
+    filename="${OUTPUT_DIR}/${number}-${safe_title}.md"
+    
+    echo "Exporting issue #${number}: ${title}"
+    
+    # Start writing the markdown file
+    cat > "$filename" << EOF
+# Issue #${number}: ${title}
+
+**State:** ${state}  
+**Author:** @${author}  
+**Created:** ${created_at}  
+**Updated:** ${updated_at}  
+
+EOF
+    
+    # Add labels if any
+    labels=$(_jq '[.labels[].name] | join(", ")')
+    if [[ -n "$labels" && "$labels" != "null" ]]; then
+        echo "**Labels:** ${labels}  " >> "$filename"
+    fi
+    
+    # Add assignees if any
+    assignees=$(_jq '[.assignees[].login] | map("@" + .) | join(", ")')
+    if [[ -n "$assignees" && "$assignees" != "null" && "$assignees" != "[]" ]]; then
+        echo "**Assignees:** ${assignees}  " >> "$filename"
+    fi
+    
+    # Add separator
+    echo -e "\n---\n" >> "$filename"
+    
+    # Add issue body
+    if [[ -n "$body" && "$body" != "null" ]]; then
+        echo -e "## Description\n\n${body}\n" >> "$filename"
+    fi
+    
+    # Fetch and add comments
+    comments_count=$(_jq '.comments | length')
+    if [[ "$comments_count" -gt 0 ]]; then
+        echo -e "## Comments\n" >> "$filename"
+        
+        # Fetch detailed comments for this issue
+        gh issue view "$number" --repo "$REPO" --comments --json comments | jq -r '.comments[] | "### Comment by @\(.author.login) on \(.createdAt)\n\n\(.body)\n\n---\n"' >> "$filename"
+    fi
+done
+
+echo "Export completed! Issues saved to: $OUTPUT_DIR"

--- a/scripts/shell/git_update.sh
+++ b/scripts/shell/git_update.sh
@@ -16,7 +16,7 @@ fi
 
 echo ''
 echo "🌿 現在のブランチ: $CURRENT_BRANCH"
-echo "🌿 ベースブランチ: $BASE_BRANCH を最新の状態にリベースします。"
+echo "🌲 ベースブランチ: $BASE_BRANCH を最新の状態にリベースします。"
 echo ''
 
 git checkout "$BASE_BRANCH"
@@ -24,7 +24,7 @@ git remote update
 git rebase "origin/$BASE_BRANCH"
 
 echo ''
-echo "🌿 ブランチ: $CURRENT_BRANCH を最新の状態にリベースします。"
+echo "♻️ 現在のブランチ: $CURRENT_BRANCH を最新の状態にリベースします。"
 echo ''
 
 git checkout -

--- a/scripts/shell/git_update.sh
+++ b/scripts/shell/git_update.sh
@@ -16,7 +16,7 @@ fi
 
 echo ''
 echo "🌿 現在のブランチ: $CURRENT_BRANCH"
-echo "🌲 ベースブランチ: $BASE_BRANCH を最新の状態にリベースします。"
+echo "🌲 ベースブランチ: $BASE_BRANCH を origin/$BASE_BRANCH にリベースします。"
 echo ''
 
 git checkout "$BASE_BRANCH"
@@ -24,7 +24,7 @@ git remote update
 git rebase "origin/$BASE_BRANCH"
 
 echo ''
-echo "♻️ 現在のブランチ: $CURRENT_BRANCH を最新の状態にリベースします。"
+echo "♻️ 現在のブランチ: $CURRENT_BRANCH を $BASE_BRANCH にリベースします。"
 echo ''
 
 git checkout -

--- a/scripts/shell/git_update.sh
+++ b/scripts/shell/git_update.sh
@@ -27,7 +27,7 @@ echo ''
 echo "♻️ 現在のブランチ: $CURRENT_BRANCH を $BASE_BRANCH にリベースします。"
 echo ''
 
-git checkout -
+git checkout "$CURRENT_BRANCH"
 git rebase "$BASE_BRANCH"
 
 echo ''


### PR DESCRIPTION
## Summary
- Add `gh-export-issues.sh` script to export GitHub issues to markdown files
- Add `ghei` alias for convenient access to the export functionality
- Support both current repository and specified repository exports

## Features
- Export all issues (open and closed) to individual markdown files
- Include full metadata: state, author, created/updated dates, labels, assignees
- Export issue comments with author and timestamp
- Configurable output directory with `-o` option
- Default output: `./issues/` for current repo, `./[repo-name]/issues/` for specified repo

## Usage
```bash
# Export current repository issues
ghei

# Export specific repository
ghei owner/repo

# Specify custom output directory
ghei -o ~/Documents/issues owner/repo
```

🤖 Generated with [Claude Code](https://claude.ai/code)