### PR TITLE
Git グローバルフックの設定を追加

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -5,6 +5,7 @@
 	root = ~/src
 [core]
 	whitespace = cr-at-eol
+	hooksPath = ~/.config/git/hooks
 [alias]
 	alias = !git config --get-regexp '^alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
 	s  = status

--- a/.config/git/hooks/pre-commit
+++ b/.config/git/hooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+branch="$(git symbolic-ref --quiet --short HEAD || echo HEAD)"
+if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+  printf "\e[31m✗  main ブランチへ直接コミットは禁止です。別ブランチを切ってください。\e[0m\n" >&2
+  exit 1
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -106,6 +106,15 @@ alias gupdate="$DOTFILES_DIR/scripts/git_update/main.sh"
 # git push && PR 作成URLの表示
 alias gp='git push -u origin HEAD && gh-pr-url'
 
+# Claude でPRをレビュー
+function claude-review() {
+  if [ -z "$1" ]; then
+    echo "使用方法: claude-review <PR番号>"
+    return 1
+  fi
+  claude -p "/review #$1 日本語で"
+}
+
 # GitHub issues export
 alias ghei='$DOTFILES_DIR/scripts/gh_export_issues/main.sh'
 


### PR DESCRIPTION
## 概要
main/master ブランチへの直接コミットを防ぐためのGitグローバルフックを設定しました。

## 変更内容
- `~/.config/git/hooks/pre-commit` フックを追加
  - main/master ブランチへの直接コミットを検出して警告・拒否
- Git グローバル設定に `core.hooksPath = ~/.config/git/hooks` を追加
  - 全ての Git リポジトリでこのフックが自動的に適用されます

## 動作確認
- main/master ブランチでコミットしようとすると「✗ main ブランチへ直接コミットは禁止です。別ブランチを切ってください。」というエラーメッセージが表示されます
- 他のブランチでは通常通りコミットできます

🤖 Generated with [Claude Code](https://claude.ai/code)