### PR TITLE
gh-pr-unapproved を gh-pr-active にリネーム

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -32,3 +32,6 @@ sftp-config.json
 
 # Claude
 **/.claude/settings.local.json
+
+# git worktree
+/.worktrees/

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,0 +1,1 @@
+set -g history-limit 100000

--- a/.zshrc
+++ b/.zshrc
@@ -115,6 +115,9 @@ function claude-review() {
   claude -p "/review #$1 日本語で"
 }
 
+# Gemini でPRをレビュー
+alias gemini-review="$DOTFILES_DIR/scripts/gemini-review/main.sh"
+
 # GitHub issues export
 alias ghei='$DOTFILES_DIR/scripts/gh_export_issues/main.sh'
 

--- a/init.sh
+++ b/init.sh
@@ -29,6 +29,11 @@ if [[ ! -L "$HOME/.config/karabiner" ]]; then
     ln -s ${SCRIPT_DIR}/.config/karabiner $HOME/.config/karabiner
 fi
 
+# tmux
+if [[ ! -L "$HOME/.tmux.conf" ]]; then
+    ln -s ${SCRIPT_DIR}/.tmux.conf $HOME/.tmux.conf
+fi
+
 # Remove localized
 ${SCRIPT_DIR}/scripts/shell/remove_localized.sh
 

--- a/scripts/gemini-review/main.sh
+++ b/scripts/gemini-review/main.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Gemini CLI PR Review Script
+# Usage: ./main.sh <pr-number> <prompt>
+
+set -euo pipefail
+
+# Check if required arguments are provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <pr-number> <prompt>"
+    echo "Example: $0 123 \"コードの品質をレビューしてください\""
+    exit 1
+fi
+
+PR_NUMBER="$1"
+PROMPT="$2"
+
+# Get PR diff using gh command
+echo "Fetching PR #${PR_NUMBER} diff..."
+PR_DIFF=$(gh pr diff "${PR_NUMBER}" || {
+    echo "Error: Failed to fetch PR diff. Make sure you're in the correct repository and have access to PR #${PR_NUMBER}"
+    exit 1
+})
+
+# Get PR title and body
+PR_INFO=$(gh pr view "${PR_NUMBER}" --json title,body,url || {
+    echo "Error: Failed to fetch PR information"
+    exit 1
+})
+
+PR_TITLE=$(echo "${PR_INFO}" | jq -r '.title')
+PR_BODY=$(echo "${PR_INFO}" | jq -r '.body // "No description"')
+PR_URL=$(echo "${PR_INFO}" | jq -r '.url')
+
+# Create the review prompt
+REVIEW_PROMPT="Pull Request Review Request
+
+PR #${PR_NUMBER}: ${PR_TITLE}
+URL: ${PR_URL}
+
+Description:
+${PR_BODY}
+
+---
+Diff:
+${PR_DIFF}
+
+---
+Review Instructions: ${PROMPT}
+
+Please provide your review response in Japanese (日本語でレビュー結果を出力してください)."
+
+# Run gemini with the prompt
+echo "Running Gemini review..."
+echo "---"
+gemini -p "${REVIEW_PROMPT}"

--- a/scripts/gh-pr-active/Makefile
+++ b/scripts/gh-pr-active/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build clean
+
+build:
+	go build -o ../../bin/gh-pr-active
+
+clean:
+	rm -f ../../bin/gh-pr-active

--- a/scripts/gh-pr-active/README.md
+++ b/scripts/gh-pr-active/README.md
@@ -1,26 +1,26 @@
-# gh-pr-unapproved
+# gh-pr-active
 
 特定のコメントが含まれていて、かつ未承認（unapproved）の PR を検索・表示する CLI ツール
 
 ## 概要
 
-`gh-pr-unapproved` は GitHub CLI (`gh`) を使用して、レビューが承認されていない PR の中から、特定のコメントを含むものを検索できるツールです。
+`gh-pr-active` は GitHub CLI (`gh`) を使用して、レビューが承認されていない PR の中から、特定のコメントを含むものを検索できるツールです。
 
 ## インストール
 
 ```bash
 # ビルド
-cd /path/to/dotfiles/scripts/gh-pr-unapproved
+cd /path/to/dotfiles/scripts/gh-pr-active
 make build
 
 # または直接go buildを実行
-go build -o ../../bin/gh-pr-unapproved
+go build -o ../../bin/gh-pr-active
 
 # PATHに /path/to/dotfiles/bin を追加していない場合は追加
 # export PATH="$PATH:/path/to/dotfiles/bin"
 
 # 直接実行
-/path/to/dotfiles/bin/gh-pr-unapproved
+/path/to/dotfiles/bin/gh-pr-active
 ```
 
 ## 使い方
@@ -28,7 +28,7 @@ go build -o ../../bin/gh-pr-unapproved
 ### ビルドせずに直接実行
 
 ```bash
-cd /path/to/dotfiles/scripts/gh-pr-unapproved
+cd /path/to/dotfiles/scripts/gh-pr-active
 go run main.go
 go run main.go -r owner/repo
 go run main.go -c "LGTM" -f json
@@ -38,22 +38,22 @@ go run main.go -c "LGTM" -f json
 
 ```bash
 # 基本的な使い方（現在のリポジトリの未承認PRを表示）
-gh-pr-unapproved
+gh-pr-active
 
 # 特定のコメントを含むPRを検索
-gh-pr-unapproved -c "LGTM"
-gh-pr-unapproved --comment "needs review"
+gh-pr-active -c "LGTM"
+gh-pr-active --comment "needs review"
 
 # 特定のリポジトリを指定
-gh-pr-unapproved -r owner/repo
-gh-pr-unapproved --repo organization/project
+gh-pr-active -r owner/repo
+gh-pr-active --repo organization/project
 
 # JSON形式で出力
-gh-pr-unapproved -f json
-gh-pr-unapproved --format json
+gh-pr-active -f json
+gh-pr-active --format json
 
 # 組み合わせ
-gh-pr-unapproved -r owner/repo -c "LGTM" -f json
+gh-pr-active -r owner/repo -c "LGTM" -f json
 ```
 
 ## オプション

--- a/scripts/gh-pr-active/go.mod
+++ b/scripts/gh-pr-active/go.mod
@@ -1,0 +1,3 @@
+module gh-pr-active
+
+go 1.21

--- a/scripts/gh-pr-active/main.go
+++ b/scripts/gh-pr-active/main.go
@@ -211,9 +211,9 @@ func main() {
 }
 
 func printHelp() {
-	fmt.Println("gh-pr-unapproved - オープンな非ドラフトPRの情報を表示")
+	fmt.Println("gh-pr-active - オープンな非ドラフトPRの情報を表示")
 	fmt.Println()
-	fmt.Println("使い方: gh-pr-unapproved [オプション]")
+	fmt.Println("使い方: gh-pr-active [オプション]")
 	fmt.Println()
 	fmt.Println("オプション:")
 	fmt.Println("  -c, --comment TEXT     PRのコメントに含まれるテキストで検索")
@@ -224,11 +224,11 @@ func printHelp() {
 	fmt.Println("  -h, --help             このヘルプメッセージを表示")
 	fmt.Println()
 	fmt.Println("例:")
-	fmt.Println("  gh-pr-unapproved                               # 現在のリポジトリのオープンPRを表示")
-	fmt.Println("  gh-pr-unapproved -c \"LGTM\"                     # \"LGTM\"を含むコメントがあるPR")
-	fmt.Println("  gh-pr-unapproved -r owner/repo -f json         # 指定リポジトリのPRをJSON形式で出力")
-	fmt.Println("  gh-pr-unapproved -l 50                         # 最大50件のPRを取得")
-	fmt.Println("  gh-pr-unapproved -s closed                     # クローズされたPRを表示")
+	fmt.Println("  gh-pr-active                               # 現在のリポジトリのオープンPRを表示")
+	fmt.Println("  gh-pr-active -c \"LGTM\"                     # \"LGTM\"を含むコメントがあるPR")
+	fmt.Println("  gh-pr-active -r owner/repo -f json         # 指定リポジトリのPRをJSON形式で出力")
+	fmt.Println("  gh-pr-active -l 50                         # 最大50件のPRを取得")
+	fmt.Println("  gh-pr-active -s closed                     # クローズされたPRを表示")
 }
 
 func getCurrentRepo() (string, error) {

--- a/scripts/gh-pr-unapproved/Makefile
+++ b/scripts/gh-pr-unapproved/Makefile
@@ -1,7 +1,0 @@
-.PHONY: build clean
-
-build:
-	go build -o ../../bin/gh-pr-unapproved
-
-clean:
-	rm -f ../../bin/gh-pr-unapproved

--- a/scripts/gh-pr-unapproved/go.mod
+++ b/scripts/gh-pr-unapproved/go.mod
@@ -1,3 +1,0 @@
-module gh-pr-unapproved
-
-go 1.21


### PR DESCRIPTION
## 概要
`gh-pr-unapproved` スクリプトを `gh-pr-active` にリネームしました。

## 変更内容
- バイナリファイル名を `bin/gh-pr-unapproved` から `bin/gh-pr-active` に変更
- ディレクトリ名を `scripts/gh-pr-unapproved/` から `scripts/gh-pr-active/` に変更
- README.md、Makefile、main.go、go.mod 内のすべての参照を更新
- Go モジュール名を `gh-pr-unapproved` から `gh-pr-active` に変更

## テストプラン
- [ ] `cd scripts/gh-pr-active && make build` でビルドが成功すること
- [ ] `bin/gh-pr-active` コマンドが正常に動作すること
- [ ] ヘルプメッセージに正しいコマンド名が表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)